### PR TITLE
Prevent deprecate message

### DIFF
--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -28,7 +28,7 @@
 
 @foreach ($columns as $column)
     @php
-        $content = $row->{$column->field} ?? null;
+        $content = $row->{$column->field} ?? '';
         $contentClassField = $column->contentClassField != '' ? $row->{$column->contentClassField} : '';
         $content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $content);
         $field = $column->dataField != '' ? $column->dataField : $column->field;


### PR DESCRIPTION
preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

<!-- Please read the guidelines and use the template below. Thanks. -->

## ⚡ PowerGrid - Pull Request

Welcome and thank you for your interest in contributing to our project!. You must use this template to submit a Pull Request or it will not be accepted.

--- 
#### Motivation

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change

#### Description

This Pull Request fixes a deprecation message

#### Related Issue(s):  #_____.

#### Documentation

 This PR requires [Documentation](https://github.com/Power-Components/powergrid-doc) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
